### PR TITLE
Support for gcc7.2.0 on @espressif esp32 xtensa toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ build.log
 targets/
 # .. and log for 'build-all'
 .build-all
+
+# OSX junk
+.fseventsd

--- a/config/cc/gcc.in
+++ b/config/cc/gcc.in
@@ -37,6 +37,11 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config CC_GCC_V_7_2_0
+    bool
+    prompt "7.2.0"
+    select CC_GCC_7
+
 config CC_GCC_V_5_2_0
     bool
     prompt "5.2.0"
@@ -367,6 +372,7 @@ config CC_GCC_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "7.2.0" if CC_GCC_V_7_2_0
     default "5.2.0" if CC_GCC_V_5_2_0
     default "linaro-4.9-2015.06" if CC_GCC_V_linaro_4_9
     default "4.9.3" if CC_GCC_V_4_9_3

--- a/config/companion_libs/expat.in
+++ b/config/companion_libs/expat.in
@@ -6,6 +6,10 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config EXPAT_V_2_2_4
+    bool
+    prompt "2.2.4"
+
 config EXPAT_V_2_1_0
     bool
     prompt "2.1.0"
@@ -16,4 +20,5 @@ config EXPAT_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "2.2.4" if EXPAT_V_2_2_4
     default "2.1.0" if EXPAT_V_2_1_0

--- a/config/companion_libs/gmp.in
+++ b/config/companion_libs/gmp.in
@@ -6,6 +6,11 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config GMP_V_6_1_2
+    bool
+    prompt "6.1.2"
+    select GMP_5_0_2_or_later
+
 config GMP_V_6_0_0
     bool
     prompt "6.0.0a"
@@ -52,6 +57,7 @@ config GMP_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "6.1.2" if GMP_V_6_1_2
     default "6.0.0a" if GMP_V_6_0_0
     default "5.1.3" if GMP_V_5_1_3
     default "5.1.1" if GMP_V_5_1_1

--- a/config/companion_libs/isl.in
+++ b/config/companion_libs/isl.in
@@ -6,6 +6,12 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config ISL_V_0_18
+    bool
+    prompt "0.18"
+    depends on CLOOG_0_18_4_or_later || CC_GCC_5_or_later
+    select ISL_V_0_18_or_later
+
 config ISL_V_0_14
     bool
     prompt "0.14"
@@ -37,6 +43,7 @@ config ISL_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "0.18" if ISL_V_0_18
     default "0.14" if ISL_V_0_14
     default "0.12.2" if ISL_V_0_12_2
     default "0.11.1" if ISL_V_0_11_1

--- a/config/companion_libs/mpfr.in
+++ b/config/companion_libs/mpfr.in
@@ -6,6 +6,10 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config MPFR_V_3_1_6
+    bool
+    prompt "3.1.6"
+
 config MPFR_V_3_1_3
     bool
     prompt "3.1.3"
@@ -44,6 +48,7 @@ config MPFR_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "3.1.6" if MPFR_V_3_1_6
     default "3.1.3" if MPFR_V_3_1_3
     default "3.1.2" if MPFR_V_3_1_2
     default "3.1.0" if MPFR_V_3_1_0

--- a/config/debug/gdb.in
+++ b/config/debug/gdb.in
@@ -33,6 +33,11 @@ choice
 # Don't remove next line
 # CT_INSERT_VERSION_BELOW
 
+config GDB_V_8_0_1
+    bool
+    prompt "8.0.1"
+    select GDB_7_2_or_later
+
 config GDB_V_7_10
     bool
     prompt "7.10"
@@ -174,6 +179,10 @@ config GDB_CUSTOM
     The choosen gdb version shall be not downloaded. Instead use
     a custom location to get the source.
 
+config GDB_8_0_1
+    bool
+    select GDB_7_0_or_later
+
 config GDB_7_2_or_later
     bool
     select GDB_7_0_or_later
@@ -197,6 +206,7 @@ config GDB_VERSION
     string
 # Don't remove next line
 # CT_INSERT_VERSION_STRING_BELOW
+    default "8.0.1" if GDB_V_8_0_1
     default "7.10" if GDB_V_7_10
     default "7.9.1" if GDB_V_7_9_1
     default "7.9" if GDB_V_7_9

--- a/patches/gcc/7.2.0/0001-WIP-don-t-bring-extra-u-int_least32_t-into-std.patch
+++ b/patches/gcc/7.2.0/0001-WIP-don-t-bring-extra-u-int_least32_t-into-std.patch
@@ -1,0 +1,26 @@
+From 81a36c012d0e6835f69e1b263f410696c3323229 Mon Sep 17 00:00:00 2001
+From: Max Filippov <jcmvbkbc@gmail.com>
+Date: Sun, 7 Jun 2015 00:35:00 +0300
+Subject: [PATCH] WIP: don't bring extra [u]int_least32_t into std::
+
+Signed-off-by: Max Filippov <jcmvbkbc@gmail.com>
+---
+ libstdc++-v3/include/std/type_traits | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libstdc++-v3/include/std/type_traits b/libstdc++-v3/include/std/type_traits
+index 03e198a..e0eb9d6 100644
+--- a/libstdc++-v3/include/std/type_traits
++++ b/libstdc++-v3/include/std/type_traits
+@@ -38,7 +38,7 @@
+ #include <bits/c++config.h>
+ 
+ #ifdef _GLIBCXX_USE_C99_STDINT_TR1
+-# if defined (__UINT_LEAST16_TYPE__) && defined(__UINT_LEAST32_TYPE__)
++# if defined (__UINT_LEAST16_TYPE__) && defined(__UINT_LEAST32_TYPE__) && 0
+ namespace std
+ {
+   typedef __UINT_LEAST16_TYPE__ uint_least16_t;
+-- 
+1.8.1.4
+

--- a/samples/xtensa-esp32-elf/crosstool.config
+++ b/samples/xtensa-esp32-elf/crosstool.config
@@ -1,21 +1,525 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# Crosstool-NG Configuration
+#
+CT_CONFIGURE_has_make381=y
+CT_CONFIGURE_has_xz=y
+CT_CONFIGURE_has_svn=y
+CT_MODULES=y
+
+#
+# Paths and misc options
+#
+
+#
+# crosstool-NG behavior
+#
+# CT_OBSOLETE is not set
 CT_EXPERIMENTAL=y
+# CT_ALLOW_BUILD_AS_ROOT is not set
+# CT_DEBUG_CT is not set
+
+#
+# Paths
+#
+CT_LOCAL_TARBALLS_DIR=""
+CT_CUSTOM_LOCATION_ROOT_DIR=""
+CT_WORK_DIR="${CT_TOP_DIR}/.build"
 CT_PREFIX_DIR="${CT_TOP_DIR}/builds/${CT_TARGET}"
+CT_INSTALL_DIR="${CT_PREFIX_DIR}"
+CT_RM_RF_PREFIX_DIR=y
+CT_REMOVE_DOCS=y
+CT_INSTALL_DIR_RO=y
+CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
+# CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
+
+#
+# Downloading
+#
+# CT_FORBID_DOWNLOAD is not set
+# CT_FORCE_DOWNLOAD is not set
+CT_CONNECT_TIMEOUT=10
+# CT_ONLY_DOWNLOAD is not set
+# CT_USE_MIRROR is not set
+
+#
+# Extracting
+#
+# CT_FORCE_EXTRACT is not set
+CT_OVERIDE_CONFIG_GUESS_SUB=y
+# CT_ONLY_EXTRACT is not set
+# CT_PATCH_BUNDLED is not set
+# CT_PATCH_LOCAL is not set
 CT_PATCH_BUNDLED_LOCAL=y
+# CT_PATCH_LOCAL_BUNDLED is not set
+# CT_PATCH_BUNDLED_FALLBACK_LOCAL is not set
+# CT_PATCH_LOCAL_FALLBACK_BUNDLED is not set
+# CT_PATCH_NONE is not set
+CT_PATCH_ORDER="bundled,local"
+CT_PATCH_USE_LOCAL=y
 CT_LOCAL_PATCH_DIR="${CT_TOP_DIR}/local-patches"
+
+#
+# Build behavior
+#
+CT_PARALLEL_JOBS=0
+CT_LOAD=""
+CT_USE_PIPES=y
+CT_EXTRA_CFLAGS_FOR_BUILD=""
+CT_EXTRA_LDFLAGS_FOR_BUILD=""
+CT_EXTRA_CFLAGS_FOR_HOST=""
+CT_EXTRA_LDFLAGS_FOR_HOST=""
+# CT_CONFIG_SHELL_SH is not set
+# CT_CONFIG_SHELL_ASH is not set
+CT_CONFIG_SHELL_BASH=y
+# CT_CONFIG_SHELL_CUSTOM is not set
+CT_CONFIG_SHELL="${bash}"
+
+#
+# Logging
+#
+# CT_LOG_ERROR is not set
+# CT_LOG_WARN is not set
+CT_LOG_INFO=y
+# CT_LOG_EXTRA is not set
+# CT_LOG_ALL is not set
+# CT_LOG_DEBUG is not set
+CT_LOG_LEVEL_MAX="INFO"
+# CT_LOG_SEE_TOOLS_WARN is not set
+CT_LOG_PROGRESS_BAR=y
+CT_LOG_TO_FILE=y
+CT_LOG_FILE_COMPRESS=y
+
+#
+# Target options
+#
+CT_ARCH="xtensa"
+CT_ARCH_SUPPORTS_BOTH_MMU=y
+CT_ARCH_SUPPORTS_32=y
+CT_ARCH_DEFAULT_HAS_MMU=y
+CT_ARCH_32=y
+CT_ARCH_BITNESS=32
 CT_TARGET_CFLAGS="-mlongcalls"
+CT_TARGET_LDFLAGS=""
+# CT_ARCH_alpha is not set
+# CT_ARCH_arm is not set
+# CT_ARCH_avr is not set
+# CT_ARCH_m68k is not set
+# CT_ARCH_microblaze is not set
+# CT_ARCH_mips is not set
+# CT_ARCH_nios2 is not set
+# CT_ARCH_powerpc is not set
+# CT_ARCH_s390 is not set
+# CT_ARCH_sh is not set
+# CT_ARCH_sparc is not set
+# CT_ARCH_x86 is not set
 CT_ARCH_xtensa=y
+CT_ARCH_alpha_AVAILABLE=y
+CT_ARCH_arm_AVAILABLE=y
+CT_ARCH_avr_AVAILABLE=y
+CT_ARCH_m68k_AVAILABLE=y
+CT_ARCH_microblaze_AVAILABLE=y
+CT_ARCH_mips_AVAILABLE=y
+CT_ARCH_nios2_AVAILABLE=y
+CT_ARCH_powerpc_AVAILABLE=y
+CT_ARCH_s390_AVAILABLE=y
+CT_ARCH_sh_AVAILABLE=y
+CT_ARCH_sparc_AVAILABLE=y
+CT_ARCH_x86_AVAILABLE=y
+CT_ARCH_xtensa_AVAILABLE=y
+CT_ARCH_SUFFIX=""
+
+#
+# Generic target options
+#
+# CT_MULTILIB is not set
+CT_ARCH_USE_MMU=y
+
+#
+# Target optimisations
+#
+CT_ARCH_FLOAT=""
+
+#
+# xtensa other options
+#
 CT_XTENSA_CUSTOM=y
+# CT_ARCH_xtensa_fsf is not set
 CT_ARCH_XTENSA_CUSTOM_NAME="esp32"
 CT_ARCH_XTENSA_CUSTOM_OVERLAY_LOCATION="${CT_TOP_DIR}/overlays"
+
+#
+# Toolchain options
+#
+
+#
+# General toolchain options
+#
+CT_FORCE_SYSROOT=y
+CT_USE_SYSROOT=y
+CT_SYSROOT_NAME="sysroot"
+CT_SYSROOT_DIR_PREFIX=""
+# CT_STATIC_TOOLCHAIN is not set
+CT_TOOLCHAIN_PKGVERSION=""
+CT_TOOLCHAIN_BUGURL=""
+
+#
+# Tuple completion and aliasing
+#
 CT_TARGET_VENDOR="esp32"
+CT_TARGET_ALIAS_SED_EXPR=""
+CT_TARGET_ALIAS=""
+
+#
+# Toolchain type
+#
+# CT_NATIVE is not set
+CT_CROSS=y
+# CT_CROSS_NATIVE is not set
+# CT_CANADIAN is not set
+CT_TOOLCHAIN_TYPE="cross"
+
+#
+# Build system
+#
+CT_BUILD=""
+CT_BUILD_PREFIX=""
+CT_BUILD_SUFFIX=""
+
+#
+# Misc options
+#
+# CT_TOOLCHAIN_ENABLE_NLS is not set
+
+#
+# Operating System
+#
+CT_BARE_METAL=y
+CT_KERNEL="bare-metal"
+CT_KERNEL_bare_metal=y
+# CT_KERNEL_linux is not set
+CT_KERNEL_bare_metal_AVAILABLE=y
+CT_KERNEL_linux_AVAILABLE=y
+CT_KERNEL_windows_AVAILABLE=y
+
+#
+# Common kernel options
+#
+
+#
+# Binary utilities
+#
+CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS="binutils"
+CT_BINUTILS_binutils=y
+
+#
+# GNU binutils
+#
+# CT_CC_BINUTILS_SHOW_LINARO is not set
+CT_BINUTILS_V_2_25_1=y
+# CT_BINUTILS_V_2_25 is not set
+# CT_BINUTILS_V_2_24 is not set
+# CT_BINUTILS_V_2_23_2 is not set
+# CT_BINUTILS_V_2_23_1 is not set
+# CT_BINUTILS_V_2_22 is not set
+# CT_BINUTILS_V_2_21_53 is not set
+# CT_BINUTILS_V_2_21_1a is not set
+# CT_BINUTILS_V_2_20_1a is not set
+# CT_BINUTILS_V_2_19_1a is not set
+# CT_BINUTILS_V_2_18a is not set
+# CT_BINUTILS_CUSTOM is not set
+CT_BINUTILS_VERSION="2.25.1"
+CT_BINUTILS_2_25_1_or_later=y
+CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_2_24_or_later=y
+CT_BINUTILS_2_23_or_later=y
+CT_BINUTILS_2_22_or_later=y
+CT_BINUTILS_2_21_or_later=y
+CT_BINUTILS_2_20_or_later=y
+CT_BINUTILS_2_19_or_later=y
+CT_BINUTILS_2_18_or_later=y
+CT_BINUTILS_HAS_HASH_STYLE=y
+CT_BINUTILS_HAS_GOLD=y
+CT_BINUTILS_HAS_PLUGINS=y
+CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
+CT_BINUTILS_LINKER_LD=y
+CT_BINUTILS_LINKERS_LIST="ld"
+CT_BINUTILS_LINKER_DEFAULT="bfd"
+# CT_BINUTILS_PLUGINS is not set
+CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+
+#
+# binutils other options
+#
+
+#
+# C-library
+#
+CT_LIBC="newlib"
+CT_LIBC_VERSION="2.2.0"
+CT_LIBC_newlib=y
+# CT_LIBC_none is not set
+CT_LIBC_avr_libc_AVAILABLE=y
+CT_LIBC_glibc_AVAILABLE=y
+CT_THREADS="none"
+CT_LIBC_mingw_AVAILABLE=y
+CT_LIBC_musl_AVAILABLE=y
+CT_LIBC_newlib_AVAILABLE=y
+# CT_CC_NEWLIB_SHOW_LINARO is not set
 CT_LIBC_NEWLIB_V_2_2_0=y
+# CT_LIBC_NEWLIB_V_2_1_0 is not set
+# CT_LIBC_NEWLIB_V_2_0_0 is not set
+# CT_LIBC_NEWLIB_V_1_20_0 is not set
+# CT_LIBC_NEWLIB_V_1_19_0 is not set
+# CT_LIBC_NEWLIB_V_1_18_0 is not set
+# CT_LIBC_NEWLIB_V_1_17_0 is not set
+# CT_LIBC_NEWLIB_CUSTOM is not set
+CT_LIBC_NEWLIB_2_2=y
+CT_LIBC_NEWLIB_2_2_or_later=y
+CT_LIBC_NEWLIB_2_1_or_later=y
+CT_LIBC_NEWLIB_2_0_or_later=y
+CT_LIBC_NEWLIB_TARGET_CFLAGS=""
+CT_LIBC_none_AVAILABLE=y
+CT_LIBC_uClibc_AVAILABLE=y
+CT_LIBC_SUPPORT_THREADS_NONE=y
+CT_LIBC_PROVIDES_CXA_ATEXIT=y
+
+#
+# Common C library options
+#
+CT_THREADS_NONE=y
+
+#
+# newlib other options
+#
+# CT_LIBC_NEWLIB_IO_C99FMT is not set
+# CT_LIBC_NEWLIB_IO_LL is not set
+# CT_LIBC_NEWLIB_IO_FLOAT is not set
 CT_LIBC_NEWLIB_DISABLE_SUPPLIED_SYSCALLS=y
-CT_CC_LANG_CXX=y
-CT_CC_GCC_V_5_2_0=y
+CT_LIBC_NEWLIB_ENABLE_TARGET_OPTSPACE=y
+CT_LIBC_NEWLIB_EXTRA_CONFIG_ARRAY=""
+
+#
+# C compiler
+#
+CT_CC="gcc"
+CT_CC_CORE_PASS_2_NEEDED=y
+CT_CC_gcc=y
+# CT_CC_GCC_SHOW_LINARO is not set
+CT_CC_GCC_V_7_2_0=y
+# CT_CC_GCC_V_5_5_0=y
+# CT_CC_GCC_V_5_2_0=y
+# CT_CC_GCC_V_4_9_3 is not set
+# CT_CC_GCC_V_4_8_5 is not set
+# CT_CC_GCC_V_4_7_4 is not set
+# CT_CC_GCC_V_4_6_4 is not set
+# CT_CC_GCC_V_4_5_4 is not set
+# CT_CC_GCC_V_4_4_7 is not set
+# CT_CC_GCC_V_4_3_6 is not set
+# CT_CC_GCC_V_4_2_4 is not set
+# CT_CC_GCC_CUSTOM is not set
+CT_CC_GCC_4_2_or_later=y
+CT_CC_GCC_4_3_or_later=y
+CT_CC_GCC_4_4_or_later=y
+CT_CC_GCC_4_5_or_later=y
+CT_CC_GCC_4_6_or_later=y
+CT_CC_GCC_4_7_or_later=y
+CT_CC_GCC_4_8_or_later=y
+CT_CC_GCC_4_9_or_later=y
+CT_CC_GCC_5=y
+CT_CC_GCC_5_or_later=y
+CT_CC_GCC_HAS_GRAPHITE=y
+CT_CC_GCC_USE_GRAPHITE=y
+CT_CC_GCC_HAS_LTO=y
+CT_CC_GCC_USE_LTO=y
+CT_CC_GCC_HAS_PKGVERSION_BUGURL=y
+CT_CC_GCC_HAS_BUILD_ID=y
+CT_CC_GCC_HAS_LNK_HASH_STYLE=y
+CT_CC_GCC_USE_GMP_MPFR=y
+CT_CC_GCC_USE_MPC=y
+CT_CC_GCC_HAS_LIBQUADMATH=y
+CT_CC_GCC_HAS_LIBSANITIZER=y
+CT_CC_GCC_VERSION="7.2.0"
+# CT_CC_LANG_FORTRAN is not set
 CT_CC_GCC_ENABLE_CXX_FLAGS="-fno-rtti -ffunction-sections"
 CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-threads=posix"
 CT_CC_GCC_EXTRA_CONFIG_ARRAY="--disable-libstdcxx-verbose --enable-threads=posix --enable-gcov-custom-rtio"
-# CT_CC_CXA_ATEXIT is not set
+CT_CC_GCC_EXTRA_ENV_ARRAY=""
+# CT_CC_GCC_TARGET_FINAL is not set
 # CT_CC_GCC_STATIC_LIBSTDCXX is not set
+# CT_CC_GCC_SYSTEM_ZLIB is not set
+
+#
+# Optimisation features
+#
+
+#
+# Settings for libraries running on target
+#
+CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
+# CT_CC_GCC_LIBMUDFLAP is not set
+# CT_CC_GCC_LIBGOMP is not set
+# CT_CC_GCC_LIBSSP is not set
+# CT_CC_GCC_LIBQUADMATH is not set
+
+#
+# Misc. obscure options.
+#
+# CT_CC_CXA_ATEXIT is not set
+# CT_CC_GCC_DISABLE_PCH is not set
 # CT_CC_GCC_LDBL_128 is not set
+# CT_CC_GCC_BUILD_ID is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
+# CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
+# CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
+CT_CC_GCC_DEC_FLOAT_AUTO=y
+# CT_CC_GCC_DEC_FLOAT_BID is not set
+# CT_CC_GCC_DEC_FLOAT_DPD is not set
+# CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_JAVA=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+
+#
+# Additional supported languages:
+#
+CT_CC_LANG_CXX=y
+CT_CC_LANG_OTHERS=""
+
+#
+# Debug facilities
+#
+# CT_DEBUG_dmalloc is not set
+# CT_DEBUG_duma is not set
 CT_DEBUG_gdb=y
+CT_GDB_CROSS=y
+# CT_GDB_CROSS_STATIC is not set
+# CT_GDB_CROSS_SIM is not set
+CT_GDB_CROSS_PYTHON=y
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY=""
+
+#
+# In bare-metal, you'll need to   
+#
+
+#
+# provide your own gdbserver stub.
+#
+
+#
+# gdb version
+#
+# CT_DEBUG_GDB_SHOW_LINARO is not set
+CT_GDB_V_8_0_1=y
+# CT_GDB_V_7_10 is not set
+# CT_GDB_V_7_9_1 is not set
+# CT_GDB_V_7_9 is not set
+# CT_GDB_V_7_8_2 is not set
+# CT_GDB_V_7_8_1 is not set
+# CT_GDB_V_7_8 is not set
+# CT_GDB_V_7_7_1 is not set
+# CT_GDB_V_7_7 is not set
+# CT_GDB_V_7_6_1 is not set
+# CT_GDB_V_7_5_1 is not set
+# CT_GDB_V_7_4_1 is not set
+# CT_GDB_V_7_4 is not set
+# CT_GDB_V_7_3_1 is not set
+# CT_GDB_V_7_3a is not set
+# CT_GDB_V_7_2a is not set
+# CT_GDB_V_7_1a is not set
+# CT_GDB_V_7_0_1a is not set
+# CT_GDB_V_7_0a is not set
+# CT_GDB_V_6_8a is not set
+# CT_GDB_CUSTOM is not set
+CT_GDB_7_2_or_later=y
+CT_GDB_7_0_or_later=y
+CT_GDB_HAS_PKGVERSION_BUGURL=y
+CT_GDB_HAS_PYTHON=y
+CT_GDB_INSTALL_GDBINIT=y
+CT_GDB_VERSION="7.10"
+# CT_DEBUG_ltrace is not set
+# CT_DEBUG_strace is not set
+
+#
+# Companion libraries
+#
+CT_COMPLIBS_NEEDED=y
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_MPC_NEEDED=y
+CT_EXPAT_NEEDED=y
+CT_NCURSES_NEEDED=y
+CT_COMPLIBS=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_MPC=y
+CT_EXPAT=y
+CT_NCURSES=y
+CT_GMP_V_6_1_2=y
+# CT_GMP_V_5_1_3 is not set
+# CT_GMP_V_5_1_1 is not set
+# CT_GMP_V_5_0_2 is not set
+# CT_GMP_V_5_0_1 is not set
+# CT_GMP_V_4_3_2 is not set
+# CT_GMP_V_4_3_1 is not set
+# CT_GMP_V_4_3_0 is not set
+CT_GMP_5_0_2_or_later=y
+CT_GMP_VERSION="6.1.2"
+CT_MPFR_V_3_1_6=y
+# CT_MPFR_V_3_1_2 is not set
+# CT_MPFR_V_3_1_0 is not set
+# CT_MPFR_V_3_0_1 is not set
+# CT_MPFR_V_3_0_0 is not set
+# CT_MPFR_V_2_4_2 is not set
+# CT_MPFR_V_2_4_1 is not set
+# CT_MPFR_V_2_4_0 is not set
+CT_MPFR_VERSION="3.1.6"
+CT_ISL_V_0_18=y
+#CT_ISL_V_0_14=y
+# CT_ISL_V_0_12_2 is not set
+CT_ISL_V_0_14_or_later=y
+CT_ISL_V_0_12_or_later=y
+CT_ISL_VERSION="0.18"
+#CT_ISL_VERSION="0.14"
+CT_MPC_V_1_0_3=y
+# CT_MPC_V_1_0_2 is not set
+# CT_MPC_V_1_0_1 is not set
+# CT_MPC_V_1_0 is not set
+# CT_MPC_V_0_9 is not set
+# CT_MPC_V_0_8_2 is not set
+# CT_MPC_V_0_8_1 is not set
+# CT_MPC_V_0_7 is not set
+CT_MPC_VERSION="1.0.3"
+CT_EXPAT_V_2_2_4=y
+CT_EXPAT_VERSION="2.2.4"
+CT_NCURSES_V_6_0=y
+CT_NCURSES_VERSION="6.0"
+# CT_NCURSES_NEW_ABI is not set
+
+#
+# Companion libraries common options
+#
+# CT_COMPLIBS_CHECK is not set
+
+#
+# Companion tools
+#
+
+#
+# READ HELP before you say 'Y' below !!!
+#
+# CT_COMP_TOOLS is not set
+
+#
+# Test suite
+#
+# CT_TEST_SUITE_GCC is not set


### PR DESCRIPTION
This is related to the ongoing PR for esp-idf:

https://github.com/espressif/esp-idf/pull/1163

Just a few version bumps on several companion libs and a gcc patch, tried some examples from the sdk and they seem to work fine.

/cc @projectgus