### PR TITLE
Allow bash version >= 5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,7 @@ CTNG_PROG_VERSION_REQ_STRICT([BASH_SHELL],
     [GNU bash >= 3.1],
     [bash],
     [bash],
-    [^GNU bash, version (3\.[1-9]|4)])
+    [^GNU bash, version (3\.[1-9]|4|5)])
 
 # We need a awk that *is* GNU awk
 CTNG_PROG_VERSION_REQ_STRICT([AWK],


### PR DESCRIPTION
Ubuntu 1904 "Disco Dingo" bash version is >= 5.0.3, change config check to allow bash versions >= 5.