### PR TITLE
Update mirror for isl package

### DIFF
--- a/packages/isl/package.desc
+++ b/packages/isl/package.desc
@@ -1,5 +1,5 @@
 repository='git git://repo.or.cz/isl.git'
 bootstrap='./autogen.sh'
-mirrors='http://isl.gforge.inria.fr'
+mirrors='https://libisl.sourceforge.io'
 milestones='0.12 0.13 0.14 0.15'
 archive_formats='.tar.xz .tar.bz2 .tar.gz'


### PR DESCRIPTION
It seems like the mirror isl.gforge.inria.fr is down. Update mirror to use libisl.sourceforge.io instead.

This should fix #17 