### PR TITLE
Make bin wrappers for 8266 as well as other chips

### DIFF
--- a/scripts/build/companion_libs/901-xtensa_esp_bin_wrappers.sh
+++ b/scripts/build/companion_libs/901-xtensa_esp_bin_wrappers.sh
@@ -95,7 +95,7 @@ do_xtensa_esp_bin_wrappers_for_target() {
     bin_wrapper=${CT_BUILD_DIR}/esp_bin_wrapper/${rust_target}/release/xtensa-toolchian-wrapper${ext}
     for file in ${CT_PREFIX_DIR}/bin/*; do
       filename=$(basename $file)
-      for chip in esp32 esp32s2 esp32s3; do
+      for chip in esp32 esp32s2 esp32s3 esp8266; do
         dst_file=${CT_PREFIX_DIR}/bin/${filename//esp/$chip}
         cp ${bin_wrapper} ${dst_file}
       done


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Adds `esp8266` to the list of target chips for which executable wrappers are generated.

This is the minimal change required to be able to build ESP8266 executables that don't require the accompanying runtime libraries, such as NodeMCU.

## Related

Issue #88 tracks this work.

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

- Build the toolchain and observe that binaries whose names begin `xtensa-esp8266-` now appear alongside binaries whose names begin e.g. `xtensa-esp32-` in the toolchain's `bin` directory;
- Build NodeMCU by pointing its `TOOLCHAIN_ROOT` at the resulting toolchain.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
