### PR TITLE
Don't use setarch if it isn't available

### DIFF
--- a/scripts/build/companion_libs/901-xtensa_esp_bin_wrappers.sh
+++ b/scripts/build/companion_libs/901-xtensa_esp_bin_wrappers.sh
@@ -55,11 +55,14 @@ do_xtensa_esp_bin_wrappers_get() {
     export RUSTUP_HOME=${CT_BUILD_DIR}/rust/rustup
     export CARGO_HOME=${CT_BUILD_DIR}/rust/cargo
     RUST_VERSION=1.86.0
+    if [[ -n "$(command -v setarch)" ]]
+    then MAYBE_SETARCH="setarch ${BUILD-%%-*}"
+    fi
 
     CT_mkdir_pushd "${CT_BUILD_DIR}/rust"
     CT_DoExecLog ALL curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh
     CT_DoExecLog ALL chmod +x rustup.sh
-    setarch ${CT_BUILD%%-*} ./rustup.sh -y \
+    ${MAYBE_SETARCH} ./rustup.sh -y \
         --no-modify-path \
         --default-toolchain "$RUST_VERSION" 2>&1
     CT_DoExecLog ALL ${CT_BUILD_DIR}/rust/cargo/bin/rustup target add $(map_triplet_to_rust ${CT_HOST})


### PR DESCRIPTION
## Description

`setarch` is used in `scripts/build/companion_libs/901-xtensa_esp_bin_wrappers.sh` to wrap `rustup.sh`. But on some platforms, `setarch` is neither required nor available.

This change avoids trying to use `setarch` if it doesn't seem to be available.

## Related

Fixes #97

## Testing

- Build any ESP toolchain on MacOS.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
